### PR TITLE
push more style prep to earlier stages

### DIFF
--- a/6_visualize.yml
+++ b/6_visualize.yml
@@ -24,8 +24,6 @@ targets:
   6_visualize/out/example_storm_frame.png:
     command: create_storm_frame(
       png_file=target_name, timestep=I('2017-09-26 11:00:00'), config=storm_frame_config,
-      view_polygon, focus_geoms, secondary_geoms,
-      storm_line_ind='2_process/out/storm_line.rds.ind',
-      storm_points_ind='2_process/out/storm_points_interp.rds.ind',
-      precip_rasters_ind='2_process/out/precip_rasters.rds.ind',
-      stream_data_ind='1_fetch/out/streamdata.rds.ind')
+      view_polygon, '5_style/out/focus_geoms.rds.ind', '5_style/out/secondary_geoms.rds.ind',
+      '5_style/out/storm_line.rds.ind', '5_style/out/storm_point_20170926_11.rds.ind',
+      '5_style/out/precip_raster_20170926_11.rds.ind', '5_style/out/streamdata_20170926_11.rds.ind')

--- a/6_visualize/src/create_storm_frame.R
+++ b/6_visualize/src/create_storm_frame.R
@@ -1,10 +1,4 @@
-create_storm_frame <- function(
-  png_file, timestep, config,
-  view_polygon, focus_geoms, secondary_geoms,
-  storm_line_ind='2_process/out/storm_line.rds.ind', storm_points_ind='2_process/out/storm_points_interp.rds.ind',
-  precip_rasters_ind='2_process/out/precip_rasters.rds.ind',
-  stream_data_ind='1_fetch/out/streamdata.rds.ind'
-) {
+create_storm_frame <- function(png_file, timestep, config, view_polygon, ...) {
 
   # open the plotting device. this should eventually be a gif function, but i don't know how that looks yet
   png(filename=png_file, width=config$width, height=config$height, units='px')
@@ -22,13 +16,13 @@ create_storm_frame <- function(
 
   # plot the pieces in order, passing through data files or R objects from the
   # scipiper pipeline
-  plot_basemap(timestep, config, view_polygon, focus_geoms, secondary_geoms)
-  add2plot_storm(timestep, config, storm_line_ind, storm_points_ind)
-  add2plot_precip(timestep, config, precip_rasters_ind)
-  add2plot_sparklines(timestep, config, stream_data_ind)
-  add2plot_datetime(timestep, config)
-  add2plot_legend(timestep, config)
-  add2plot_USGS_logo(timestep, config)
+  plot_basemap(timestep, config, view_polygon)
+
+  files_to_map <- c(...)
+  for (ind_file in files_to_map){
+    map_data <- readRDS(gd_get(ind_file))
+    do.call(plot, map_data)
+  }
 
   # close off the plotting device
   dev.off()

--- a/6_visualize/src/placeholder
+++ b/6_visualize/src/placeholder
@@ -1,1 +1,0 @@
-Placeholder


### PR DESCRIPTION
This is what I had in mind. it is similar to your proposal, but puts more pre-processing ahead of this stage, so that the creation of a single frame is lighter. 

Instead of having custom plot functions (other than `plot_basemap`), we'd set up inputs as lists that can be `do.call`'d with `plot` as the function. So this means all of the styling and inputs would be pre-processed. 

Additionally, we'd use task tables to break out the time varying components of the plot into separate files (here I named them w/ some derivative of the timestep), so the pre-slicing would be done before we hit `6_visualize`. 